### PR TITLE
Dcc base stationlib

### DIFF
--- a/DCCBaseStation.cpp
+++ b/DCCBaseStation.cpp
@@ -125,7 +125,7 @@ void DCCBaseStation::setLocoSpeed(unsigned int locoAddress, byte locoSpeed, DCCD
 
   //check high prioriy list
   for (currentPacket = _priorityList->_packetLists[HIGH_PRIORITY_LIST]->firstPacket; currentPacket != NULL; currentPacket = currentPacket->nextPacket) {
-    if (currentPacket->locoAddress == locoAddress) { //hit
+    if (currentPacket->locoAddress == locoAddress && currentPacket->instructionType == LOCOSPEED) { //hit
       packetList = _priorityList->_packetLists[HIGH_PRIORITY_LIST];
       break;
     }
@@ -134,7 +134,7 @@ void DCCBaseStation::setLocoSpeed(unsigned int locoAddress, byte locoSpeed, DCCD
   //check critical priority list
   if (currentPacket == NULL) {
     for (currentPacket = _priorityList->_packetLists[CRITICAL_PRIORITY_LIST]->firstPacket; currentPacket != NULL; currentPacket = currentPacket->nextPacket) {
-      if (currentPacket->locoAddress == locoAddress) { //hit
+      if (currentPacket->locoAddress == locoAddress && currentPacket->instructionType == LOCOSPEED) { //hit
         packetList = _priorityList->_packetLists[CRITICAL_PRIORITY_LIST];
         break;
       }
@@ -151,6 +151,11 @@ void DCCBaseStation::setLocoSpeed(unsigned int locoAddress, byte locoSpeed, DCCD
         currentPacket =  &(_priorityList->packets[i]);
         currentPacket->locoAddress = locoAddress;
         currentPacket->instructionByte = 0;
+        currentPacket->instructionType = LOCOSPEED;
+
+        setLocoF0F4Functions(locoAddress, 0);
+        setLocoF5F8Functions(locoAddress, 0);
+        
         break;
       }
     }
@@ -193,7 +198,7 @@ void DCCBaseStation::setLocoSpeed(unsigned int locoAddress, byte locoSpeed, DCCD
   markPacketUpdated(currentPacket, packetList);
 }
 
-void DCCBaseStation::setLocoFunctions(unsigned int locoAddress, byte locoF0F4) {
+void DCCBaseStation::setLocoF0F4Functions(unsigned int locoAddress, byte locoF0F4) {
   //find out wheter a function group one packet is already in the lists
   //function stuff is low priority
   DCCBufferPacket * currentPacket = NULL;
@@ -201,7 +206,7 @@ void DCCBaseStation::setLocoFunctions(unsigned int locoAddress, byte locoF0F4) {
 
   //check low prioriy list
   for (currentPacket = _priorityList->_packetLists[LOW_PRIORITY_LIST]->firstPacket; currentPacket != NULL; currentPacket = currentPacket->nextPacket) {
-    if (currentPacket->locoAddress == locoAddress) { //hit
+    if (currentPacket->locoAddress == locoAddress && currentPacket->instructionType == FUNCTIONF0F4) { //hit
       packetList = _priorityList->_packetLists[LOW_PRIORITY_LIST];
       break;
     }
@@ -217,6 +222,7 @@ void DCCBaseStation::setLocoFunctions(unsigned int locoAddress, byte locoF0F4) {
         currentPacket =  &(_priorityList->packets[i]);
         currentPacket->locoAddress = locoAddress;
         currentPacket->instructionByte = 0;
+        currentPacket->instructionType = FUNCTIONF0F4;
         break;
       }
     }
@@ -237,6 +243,52 @@ void DCCBaseStation::setLocoFunctions(unsigned int locoAddress, byte locoF0F4) {
 
   markPacketUpdated(currentPacket, packetList);
 
+}
+
+void DCCBaseStation::setLocoF5F8Functions(unsigned int locoAddress, byte locoF5F8) {
+  //find out wheter a function group one packet is already in the lists
+  //function stuff is low priority
+  DCCBufferPacket * currentPacket = NULL;
+  DCCPacketList * packetList = NULL;
+
+  //check low prioriy list
+  for (currentPacket = _priorityList->_packetLists[LOW_PRIORITY_LIST]->firstPacket; currentPacket != NULL; currentPacket = currentPacket->nextPacket) {
+    if (currentPacket->locoAddress == locoAddress && currentPacket->instructionType == FUNCTIONF5F8) { //hit
+      packetList = _priorityList->_packetLists[LOW_PRIORITY_LIST];
+      break;
+    }
+  }
+
+  //create packet if not found
+  if (currentPacket == NULL) {
+    //find first available spot
+    for ( int i = 0; i < _priorityList->packetCount; i++ ) {
+      if ( _priorityList->packets[i].locoAddress == 0x00 || _priorityList->packets[i].locoAddress == 0xFF) {
+        Serial.print("Spawning packet in slot: ");
+        Serial.println(i, DEC);
+        currentPacket =  &(_priorityList->packets[i]);
+        currentPacket->locoAddress = locoAddress;
+        currentPacket->instructionByte = 0;
+        currentPacket->instructionType = FUNCTIONF5F8;
+        break;
+      }
+    }
+
+    //function packets go into low priority list
+    packetList = _priorityList->_packetLists[LOW_PRIORITY_LIST];
+    movePacket(currentPacket, NULL, packetList);
+  }
+
+  //setup packet with new data
+  const byte byteCount = 3;
+  byte bytes[byteCount];
+  bytes[0] = highByte(locoAddress) | 0xC0;
+  bytes[1] = lowByte(locoAddress);
+  bytes[2] = (locoF5F8 & 0x0F) | 0xB0;
+
+  setupPacket(currentPacket, bytes, byteCount);
+
+  markPacketUpdated(currentPacket, packetList);
 }
 
 void DCCBaseStation::setupPacket(DCCBufferPacket * packet, byte * bytes, byte byteCount) {

--- a/DCCBaseStation.h
+++ b/DCCBaseStation.h
@@ -97,7 +97,7 @@ class DCCBaseStation {
         DCCPacketList ** _packetLists;
         DCCPriorityList(byte packetCount);
         DCCRawPacket _idlePacket;
-        
+
       private:
         DCCPacketList *  initPacketList(byte packetCount);
     };
@@ -113,7 +113,7 @@ class DCCBaseStation {
     void enableTrackPower();
     boolean checkCurrentDraw();
     void setLocoSpeed(unsigned int locoAddress, byte locoSpeed, DCCDirection locoDirection);
-
+    void setLocoFunctions(unsigned int locoAddress, byte locoF0F4);
 
   private:
     void movePacket(DCCBufferPacket * movedPacket, DCCPacketList * fromList, DCCPacketList * toList);

--- a/DCCBaseStation.h
+++ b/DCCBaseStation.h
@@ -41,6 +41,13 @@
 
 class DCCBaseStation {
   public:
+    typedef enum {
+      LOCOSPEED,
+      FUNCTIONF0F4,
+      FUNCTIONF5F8,
+      FUNCTIONF9F12,
+    } DCCInstruction;
+
     /**
       The DCCRawPacket consists of data ready to transmit to the track with minimal overhead in interrupt routines.
     */
@@ -62,6 +69,7 @@ class DCCBaseStation {
       public:
         DCCRawPacket rawPackets[2]; /**Data at index 0 is always new stuff. Data at index 1 is always stuff potentially currently being transmitted*/
         unsigned int locoAddress;
+        DCCInstruction instructionType;
         byte instructionByte;
         unsigned long lastUpdateMillis;
         DCCBufferPacket * nextPacket;
@@ -83,6 +91,8 @@ class DCCBaseStation {
         DCCBufferPacket ** newOrUpdatedPackets;
         byte firstNewOrUpdatedIndex = 0;
         byte newOrUpdatedCount = 0;
+
+        DCCBufferPacket * findPacket(unsigned int locoAddress, DCCInstruction dccInstruction);
     };
 
     class DCCPriorityList
@@ -107,19 +117,25 @@ class DCCBaseStation {
       REVERSE
     } DCCDirection;
 
+
+
     DCCBaseStation(byte dccSignalPin, byte enablePin, byte currentSensePin, byte registerCount);
     void begin(byte timerNo);
     volatile DCCPriorityList * const getPriorityList() const;
     void enableTrackPower();
     boolean checkCurrentDraw();
     void setLocoSpeed(unsigned int locoAddress, byte locoSpeed, DCCDirection locoDirection);
-    void setLocoFunctions(unsigned int locoAddress, byte locoF0F4);
+    void setLocoF0F4Functions(unsigned int locoAddress, byte locoF0F4);
+    void setLocoF5F8Functions(unsigned int locoAddress, byte locoF5F8);
 
   private:
-    void movePacket(DCCBufferPacket * movedPacket, DCCPacketList * fromList, DCCPacketList * toList);
     void markPacketUpdated(DCCBufferPacket * currentPacket, DCCPacketList * packetList);
     void setupPacket(DCCBufferPacket * packet, byte * bytes, byte byteCount);
     void setupPacketBitStream(volatile DCCRawPacket * packet, byte * bytes, byte byteCount);
+
+    void movePacket(DCCBufferPacket * movedPacket, DCCPacketList * fromList, DCCPacketList * toList);
+    DCCBufferPacket * createPacket(unsigned int locoAddress, DCCInstruction dccInstruction, DCCPacketList * packetList);
+
     volatile DCCPriorityList * const _priorityList;
     CurrentMonitor * _currentMonitor;
     byte _enablePin;

--- a/LoconetMaster.cpp
+++ b/LoconetMaster.cpp
@@ -149,6 +149,8 @@ void LoconetMaster::processReceivedMessages()
     {
       byte slotNumber = receivedMessage->data[1];
       _slotData[slotNumber - 1].directionF0F4 = receivedMessage->data[2];
+
+      byte locoF0F4 = _slotData[slotNumber - 1].directionF0F4 & 0x1F; //Strip direction info
     }
   }
 }

--- a/LoconetMaster.cpp
+++ b/LoconetMaster.cpp
@@ -151,6 +151,7 @@ void LoconetMaster::processReceivedMessages()
       _slotData[slotNumber - 1].directionF0F4 = receivedMessage->data[2];
 
       byte locoF0F4 = _slotData[slotNumber - 1].directionF0F4 & 0x1F; //Strip direction info
+      _dccBaseStation->setLocoFunctions(_slotData[slotNumber - 1].locoAddress, locoF0F4);
     }
   }
 }

--- a/LoconetMaster.cpp
+++ b/LoconetMaster.cpp
@@ -60,6 +60,7 @@ byte LoconetMaster::createLocoSlot(int locoAddress) {
       Serial.print(locoAddress, DEC);
       Serial.print(". Slot number: ");
       Serial.println(slotIndex + 1, DEC);
+
       return slotIndex + 1;
     }
   }
@@ -151,7 +152,15 @@ void LoconetMaster::processReceivedMessages()
       _slotData[slotNumber - 1].directionF0F4 = receivedMessage->data[2];
 
       byte locoF0F4 = _slotData[slotNumber - 1].directionF0F4 & 0x1F; //Strip direction info
-      _dccBaseStation->setLocoFunctions(_slotData[slotNumber - 1].locoAddress, locoF0F4);
+      _dccBaseStation->setLocoF0F4Functions(_slotData[slotNumber - 1].locoAddress, locoF0F4);
+    }
+    else if (receivedMessage->data[0] == OPC_LOCO_SND )
+    {
+      byte slotNumber = receivedMessage->data[1];
+      _slotData[slotNumber - 1].slotSound = receivedMessage->data[2];
+
+      byte locoF5F8 = _slotData[slotNumber - 1].slotSound & 0x0F; //zero the bits that should be zero anyways for extra paranoia
+      _dccBaseStation->setLocoF5F8Functions(_slotData[slotNumber - 1].locoAddress, locoF5F8);
     }
   }
 }
@@ -170,7 +179,7 @@ void LoconetMaster::sendSlotReadData(byte slotNumber)
     replyMessage.data[ 7 ] = 4;//1; //TRK Track Status power is on
     replyMessage.data[ 8 ] = 0; //SS2 Status 2
     replyMessage.data[ 9 ] = _slotData[slotNumber - 1].locoAddress >> 8; //0x04; //ADR2 Address msb
-    replyMessage.data[ 10 ] = 0; //SND
+    replyMessage.data[ 10 ] = _slotData[slotNumber - 1].slotSound; //SND
     replyMessage.data[ 11 ] = _slotData[slotNumber - 1].deviceID >> 8;
     replyMessage.data[ 12 ] = _slotData[slotNumber - 1].deviceID & 0x00FF;
 

--- a/LoconetMaster.h
+++ b/LoconetMaster.h
@@ -36,6 +36,7 @@ class LoconetMaster
       int locoAddress = 0;
       byte locoSpeed = 0;
       byte directionF0F4 = 0;
+      byte slotSound = 0;
       int deviceID = 0;
     } SlotData;
 


### PR DESCRIPTION
Added support for functions f0-f8. When a new loco address is registered, the instructions for f0-f8 are automatically generated setting the functions to off. (Some decoder remember their settings after a power down resulting in a little bit goofy behaviour)